### PR TITLE
Create broadcast group

### DIFF
--- a/server/__tests__/add-group.tests.js
+++ b/server/__tests__/add-group.tests.js
@@ -1,0 +1,63 @@
+/* eslint-disable no-undef */
+const request = require('supertest');
+const { Group } = require('../models');
+
+const app = require('../server');
+const { HttpError } = require('../utils/errors');
+
+let server;
+jest.mock('../models', () => ({
+  Group: jest.fn()
+}));
+jest.mock('../utils/token-helpers', () => ({
+  authenticateToken: jest.fn().mockImplementation((req, res, next) => next()),
+  getBearerToken: jest.fn().mockImplementation(() => 'token')
+}));
+beforeAll(() => {
+  server = app.listen(3001);
+});
+
+afterAll(() => {
+  server.close();
+});
+
+const record = {
+  name: 'The cool boys'
+};
+
+const { name } = record;
+
+const token = 'token';
+
+const baseURL = 'http://localhost:3001';
+
+describe('When a user adds a group', () => {
+  it('should return correct status code if the group name is not submitted', async () => {
+    const response = await request(baseURL).post('/api/group').set('Authorization', `Bearer ${token}`).send({});
+    expect(response.statusCode).toBe(400);
+    expect(response.body.message).toBe('Invalid Payload');
+  });
+
+  it('should return correct status code if the group name has been submitted', async () => {
+    Group.mockImplementationOnce(() => ({
+      save: jest.fn(() => Promise.resolve()),
+    }));
+    const response = await request(baseURL).post('/api/group').set('Authorization', `Bearer ${token}`).send({ name });
+    expect(response.statusCode).toBe(201);
+  });
+  it('should return correct status code if the group name has been submitted already exists', async () => {
+    Group.mockImplementationOnce(() => ({
+      save: jest.fn(() => Promise.reject(new HttpError(409, 'Group already exists'))),
+    }));
+    const response = await request(baseURL).post('/api/group').set('Authorization', `Bearer ${token}`).send({ name });
+    expect(response.statusCode).toBe(409);
+  });
+
+  it('should return correct status code on an unexpected error', async () => {
+    Group.mockImplementationOnce(() => ({
+      save: jest.fn(() => Promise.reject(new Error(500, 'Interval server'))),
+    }));
+    const response = await request(baseURL).post('/api/group').set('Authorization', `Bearer ${token}`).send({ name });
+    expect(response.statusCode).toBe(500);
+  });
+});

--- a/server/__tests__/group.test.js
+++ b/server/__tests__/group.test.js
@@ -1,0 +1,17 @@
+/* eslint-disable no-undef */
+const { Group } = require('../models');
+const { HttpError } = require('../utils/errors');
+
+const record = {
+  name: 'The cool guys',
+};
+
+const { name } = record;
+const token = 'token';
+const group = new Group(name, token);
+describe('When a user adds a group', () => {
+  it('it should throw an error if the group already exists', async () => {
+    jest.spyOn(group, 'groupByUserExists').mockImplementationOnce(() => Promise.reject(new HttpError(409, 'Group by user already exists')));
+    await expect(group.save()).rejects.toThrow('Group by user already exists');
+  });
+});

--- a/server/__tests__/group.test.js
+++ b/server/__tests__/group.test.js
@@ -11,7 +11,7 @@ const token = 'token';
 const group = new Group(name, token);
 describe('When a user adds a group', () => {
   it('it should throw an error if the group already exists', async () => {
-    jest.spyOn(group, 'groupByUserExists').mockImplementationOnce(() => Promise.reject(new HttpError(409, 'Group by user already exists')));
+    jest.spyOn(group, 'isDuplicate').mockImplementationOnce(() => Promise.reject(new HttpError(409, 'Group by user already exists')));
     await expect(group.save()).rejects.toThrow('Group by user already exists');
   });
 });

--- a/server/models/groups.js
+++ b/server/models/groups.js
@@ -1,0 +1,57 @@
+const { verifyAccessToken } = require('../utils/token-helpers');
+const { HttpError } = require('../utils/errors');
+const prisma = require('../db');
+
+class Group {
+  constructor(name, token) {
+    this.name = name;
+    this.token = token;
+  }
+
+  async groupByUserExists() {
+    const { token, name } = this;
+    const user = verifyAccessToken(token);
+
+    if (!user) {
+      throw new HttpError(401, 'Not Authorised');
+    }
+    const record = await prisma.Group.findUnique({
+      where: {
+        name
+      }
+    });
+
+    if (record) {
+      if (record.groupAdmin === user.id) {
+        throw new HttpError(409, 'Group by user already exists');
+      }
+    }
+  }
+
+  async addGroup() {
+    const { token, name } = this;
+    const user = verifyAccessToken(token);
+
+    await prisma.Group.create({
+      data: {
+        name,
+        groupAdmin: user.id
+      }
+    });
+
+    const group = await prisma.$queryRaw`SELECT "id" FROM "Group" WHERE "name" = ${name} AND "groupAdmin" = ${user.id}`;
+
+    await prisma.GroupMembership.create({
+      data: {
+        group_id: group[0].id,
+        user_id: user.id
+      }
+    });
+  }
+
+  async save() {
+    await this.groupByUserExists();
+    await this.addGroup();
+  }
+}
+module.exports = Group;

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,5 +1,7 @@
 const User = require('./users');
+const Group = require('./groups');
 
 module.exports = {
   User,
+  Group
 };

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -91,6 +91,9 @@ class User {
       throw new HttpError(400, 'Bad request');
     }
     const record = verifyRefreshToken(rToken);
+    if (!record) {
+      throw new HttpError(401, 'Invalid Token - Please log in');
+    }
     await prisma.RefreshTokens.delete({
       where: rToken
     });

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -20,11 +20,16 @@ model User{
 
 model Group{
   id Int @id @default(autoincrement())
-  name String @db.VarChar(255)
-  groupAdmin Int
+  name String @unique @db.VarChar(255)
+  group_admin Int
 }
 
 model RefreshTokens{
   id Int @id @default(autoincrement())
   token String @unique @db.VarChar(1000)
+}
+
+model GroupMembership{
+  id Int @id @default(autoincrement())
+  group_id Int
 }

--- a/server/routes/group/create-broadcast-group.js
+++ b/server/routes/group/create-broadcast-group.js
@@ -1,19 +1,18 @@
 const express = require('express');
-const { authenticateToken } = require('../../utils/token-helpers');
 const { HttpError } = require('../../utils/errors');
 const { Group } = require('../../models');
-const { getBearerToken } = require('../../utils/token-helpers');
+const { authenticateToken } = require('../../utils/token-helpers');
 
 const router = express.Router();
 router.post('/group', authenticateToken, async (req, res) => {
   const { name } = req.body;
-  const token = getBearerToken(req);
-
+  const { id } = req.user;
   if (!name) {
     return res.status(400).json({ message: 'Invalid Payload' });
   }
-  const group = new Group(name, token);
+
   try {
+    const group = new Group(name, id);
     await group.save();
     return res.status(201).json({ message: `${name} group has been successfully created` });
   } catch (error) {

--- a/server/routes/group/create-broadcast-group.js
+++ b/server/routes/group/create-broadcast-group.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const { authenticateToken } = require('../../utils/token-helpers');
+const { HttpError } = require('../../utils/errors');
+const { Group } = require('../../models');
+const { getBearerToken } = require('../../utils/token-helpers');
+
+const router = express.Router();
+router.post('/group', authenticateToken, async (req, res) => {
+  const { name } = req.body;
+  const token = getBearerToken(req);
+
+  if (!name) {
+    return res.status(400).json({ message: 'Invalid Payload' });
+  }
+  const group = new Group(name, token);
+  try {
+    await group.save();
+    return res.status(201).json({ message: `${name} group has been successfully created` });
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return res.status(error.statusCode).json({ message: error.message });
+    }
+    return res.status(500).json({ message: error.message });
+  }
+});
+module.exports = router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -2,10 +2,12 @@ const signupRouter = require('./user/signup');
 const signinRouter = require('./user/signin');
 const refreshTokenRouter = require('./user/refresh-token');
 const logoutRouter = require('./user/logout');
+const createBroadcastGroupRouter = require('./group/create-broadcast-group');
 
 module.exports = {
   signupRouter,
   signinRouter,
   refreshTokenRouter,
-  logoutRouter
+  logoutRouter,
+  createBroadcastGroupRouter
 };

--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const {
-  signupRouter, signinRouter, refreshTokenRouter, logoutRouter
+  signupRouter, signinRouter, refreshTokenRouter, logoutRouter, createBroadcastGroupRouter
 } = require('./routes');
 
 const app = express();
@@ -11,4 +11,5 @@ app.use('/api/user', signupRouter);
 app.use('/api/user', signinRouter);
 app.use('/api', logoutRouter);
 app.use('/api', refreshTokenRouter);
+app.use('/api', createBroadcastGroupRouter);
 module.exports = app;

--- a/server/utils/token-helpers/authenticate-token.js
+++ b/server/utils/token-helpers/authenticate-token.js
@@ -1,15 +1,14 @@
-const { HttpError } = require('../errors');
 const getBearerToken = require('./get-bearer-token');
 const verifyAccessToken = require('./verify-access-token');
 
 function authenticateToken(req, res, next) {
   const token = getBearerToken(req);
   if (token == null) {
-    throw new HttpError(401, 'Not Authorised');
+    return res.status(401).json({ message: 'Not Authorized' });
   }
   const user = verifyAccessToken(token);
   if (!user) {
-    throw new HttpError(401, 'Invalid Token');
+    return res.status(401).json({ message: 'Invalid token' });
   }
   req.user = user;
   next();

--- a/server/utils/token-helpers/authenticate-token.js
+++ b/server/utils/token-helpers/authenticate-token.js
@@ -1,0 +1,18 @@
+const { HttpError } = require('../errors');
+const getBearerToken = require('./get-bearer-token');
+const verifyAccessToken = require('./verify-access-token');
+
+function authenticateToken(req, res, next) {
+  const token = getBearerToken(req);
+  if (token == null) {
+    throw new HttpError(401, 'Not Authorised');
+  }
+  const user = verifyAccessToken(token);
+  if (!user) {
+    throw new HttpError(401, 'Invalid Token');
+  }
+  req.user = user;
+  next();
+}
+
+module.exports = authenticateToken;

--- a/server/utils/token-helpers/index.js
+++ b/server/utils/token-helpers/index.js
@@ -2,10 +2,14 @@ const generateAccessToken = require('./generate-access-token');
 const generateRefreshToken = require('./generate-refresh-token');
 const getBearerToken = require('./get-bearer-token');
 const verifyRefreshToken = require('./verify-refresh-token');
+const verifyAccessToken = require('./verify-access-token');
+const authenticateToken = require('./authenticate-token');
 
 module.exports = {
   generateAccessToken,
   generateRefreshToken,
   getBearerToken,
-  verifyRefreshToken
+  verifyRefreshToken,
+  verifyAccessToken,
+  authenticateToken
 };

--- a/server/utils/token-helpers/verify-access-token.js
+++ b/server/utils/token-helpers/verify-access-token.js
@@ -1,0 +1,12 @@
+require('dotenv').config();
+const jwt = require('jsonwebtoken');
+const { HttpError } = require('../errors');
+
+function verifyAccessToken(token) {
+  const record = jwt.verify(token, process.env.ACCESS_TOKEN_SECRET);
+  if (!record) {
+    throw new HttpError(401, 'Not Authorised');
+  }
+  return record;
+}
+module.exports = verifyAccessToken;

--- a/server/utils/token-helpers/verify-access-token.js
+++ b/server/utils/token-helpers/verify-access-token.js
@@ -1,12 +1,11 @@
 require('dotenv').config();
 const jwt = require('jsonwebtoken');
-const { HttpError } = require('../errors');
 
 function verifyAccessToken(token) {
-  const record = jwt.verify(token, process.env.ACCESS_TOKEN_SECRET);
-  if (!record) {
-    throw new HttpError(401, 'Not Authorised');
-  }
-  return record;
+  try {
+    const record = jwt.verify(token, process.env.ACCESS_TOKEN_SECRET);
+    console.log(record)
+    return record;
+  } catch (error) { return false; }
 }
 module.exports = verifyAccessToken;

--- a/server/utils/token-helpers/verify-refresh-token.js
+++ b/server/utils/token-helpers/verify-refresh-token.js
@@ -1,12 +1,10 @@
 require('dotenv').config();
 const jwt = require('jsonwebtoken');
-const { HttpError } = require('../errors');
 
 function verifyRefreshToken(token) {
-  const record = jwt.verify(token, process.env.REFRESH_TOKEN_SECRET);
-  if (!record) {
-    throw new HttpError(401, 'Not Authorised');
-  }
-  return record;
+  try {
+    const record = jwt.verify(token, process.env.REFRESH_TOKEN_SECRET);
+    return record;
+  } catch (error) { return false; }
 }
 module.exports = verifyRefreshToken;


### PR DESCRIPTION
**What does this PR do?**
This PR enables users to add groups in to the PostIt Application.

**Description of the task to be completed**
For registered users to be able to create groups

**Why do we need this feature?**
To enable users to create broadcast groups and send and receive messages to and from the groups they belong

**How can this feature be manually tested?**
Using **Postman** POST:` http:localhost:3000/api/group`

Post a JSON object in the form
```
{
    "name": groupName",
}
```
to add a group

**Testing** 


```
npm run test

```