### PR TITLE
Add users to a group

### DIFF
--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -4,7 +4,7 @@
         "commonjs": true,
         "es2021": true
     },
-    "extends": "airbnb-base",
+    "extends": "eslint:recommended",
     "overrides": [
     ],
     "parserOptions": {
@@ -18,7 +18,6 @@
         "no-param-reassign": 0,
         "comma-dangle": 0,
         "curly": ["error", "multi-line"],
-        "import/no-unresolved": [2, { "commonjs": true }],
         "no-shadow": ["error", { "allow": ["req", "res", "err"] }]
         
       }

--- a/server/__tests__/add-group-users-tests.js
+++ b/server/__tests__/add-group-users-tests.js
@@ -1,0 +1,57 @@
+/* eslint-disable no-undef */
+const request = require('supertest');
+const { Group } = require('../models');
+
+const app = require('../server');
+const { HttpError } = require('../utils/errors');
+
+let server;
+// jest.mock('../models', () => ({
+//   Group: jest.fn()
+// }));
+jest.mock('../utils/token-helpers', () => ({
+    authenticateToken: jest.fn().mockImplementation((req, res, next) => {
+        const user = {
+            id: '1'
+        };
+        req.user = user;
+        next();
+    }),
+}));
+beforeAll(() => {
+    server = app.listen(3001);
+});
+
+afterAll(() => {
+    server.close();
+});
+
+const data = [{ user_id: 345 }, { user_id: 543 }];
+const token = 'token';
+
+const baseURL = 'http://localhost:3001';
+
+describe('When a user adds group users', () => {
+    it('should return correct status code if the users data is not submitted', async () => {
+        const response = await request(baseURL).post('/api/group/:id/user').set('Authorization', `Bearer ${token}`).send({});
+        expect(response.statusCode).toBe(400);
+        expect(response.body.message).toBe('Invalid Payload');
+    });
+
+    it('should return correct status code if the users data has been submitted', async () => {
+        jest.spyOn(Group, 'addUsers').mockImplementationOnce(() => Promise.resolve());
+        const response = await request(baseURL).post('/api/group/:id/user').set('Authorization', `Bearer ${token}`).send({ data });
+        expect(response.statusCode).toBe(201);
+    });
+    it('should return correct status code if the user is not authorized to add users to group', async () => {
+        jest.spyOn(Group, 'addUsers').mockImplementationOnce(() => Promise.reject(new HttpError(403, 'Only the Group administrator can add users')));
+        const response = await request(baseURL).post('/api/group/:id/user').set('Authorization', `Bearer ${token}`).send({ data });
+        expect(response.statusCode).toBe(403);
+    });
+
+    it('should return correct status code on an unexpected error', async () => {
+        jest.spyOn(Group, 'addUsers').mockImplementationOnce(() => Promise.reject(new Error(500, 'Internal Server Error')));
+        const response = await request(baseURL).post('/api/group/:id/user').set('Authorization', `Bearer ${token}`).send({ data });
+        expect(response.statusCode).toBe(500);
+    });
+});

--- a/server/__tests__/add-group-users-tests.js
+++ b/server/__tests__/add-group-users-tests.js
@@ -6,9 +6,7 @@ const app = require('../server');
 const { HttpError } = require('../utils/errors');
 
 let server;
-// jest.mock('../models', () => ({
-//   Group: jest.fn()
-// }));
+
 jest.mock('../utils/token-helpers', () => ({
     authenticateToken: jest.fn().mockImplementation((req, res, next) => {
         const user = {

--- a/server/__tests__/group.test.js
+++ b/server/__tests__/group.test.js
@@ -3,15 +3,28 @@ const { Group } = require('../models');
 const { HttpError } = require('../utils/errors');
 
 const record = {
-  name: 'The cool guys',
+    name: 'The cool guys',
 };
-
+const data = [{ user_id: 345 }, { user_id: 543 }];
+const groupId = 1;
+const userId = 1;
 const { name } = record;
 const token = 'token';
 const group = new Group(name, token);
 describe('When a user adds a group', () => {
-  it('it should throw an error if the group already exists', async () => {
-    jest.spyOn(group, 'isDuplicate').mockImplementationOnce(() => Promise.reject(new HttpError(409, 'Group by user already exists')));
-    await expect(group.save()).rejects.toThrow('Group by user already exists');
-  });
+    it('it should throw an error if the group already exists', async () => {
+        jest
+            .spyOn(group, 'isDuplicate')
+            .mockImplementationOnce(() => Promise.reject(new HttpError(409, 'Group by user already exists')));
+        await expect(group.save()).rejects.toThrow('Group by user already exists');
+    });
+});
+
+describe('When a user adds users to a group', () => {
+    it('it should throw an error if the user is not authorized to add users to a group', async () => {
+        jest
+            .spyOn(Group, 'isGroupAdmin')
+            .mockImplementationOnce(() => Promise.reject(new HttpError(403, 'Only the Group administrator can add users')));
+        await expect(Group.addUsers(data, groupId, userId)).rejects.toThrow('Only the Group administrator can add users');
+    });
 });

--- a/server/models/groups.js
+++ b/server/models/groups.js
@@ -1,50 +1,101 @@
+/* eslint-disable no-restricted-syntax */
 const { HttpError } = require('../utils/errors');
 const prisma = require('../db');
 
 class Group {
-  constructor(name, id) {
-    this.name = name;
-    this.id = id;
-  }
-
-  async isDuplicate() {
-    const { id, name } = this;
-    const record = await prisma.Group.findUnique({
-      where: {
-        name
-      }
-    });
-
-    if (record) {
-      if (record.groupAdmin === id) {
-        throw new HttpError(409, 'Group by user already exists');
-      }
+    constructor(name, id) {
+        this.name = name;
+        this.id = id;
     }
-  }
 
-  async createGroup() {
-    const { id, name } = this;
+    async isDuplicate() {
+        const { id, name } = this;
+        const record = await prisma.Group.findUnique({
+            where: {
+                name,
+            },
+        });
 
-    await prisma.Group.create({
-      data: {
-        name,
-        groupAdmin: id
-      }
-    });
+        if (record) {
+            if (record.groupAdmin === id) {
+                throw new HttpError(409, 'Group by user already exists');
+            }
+        }
+    }
 
-    const group = await prisma.$queryRaw`SELECT "id" FROM "Group" WHERE "name" = ${name} AND "groupAdmin" = ${id}`;
+    async createGroup() {
+        const { id, name } = this;
 
-    await prisma.GroupMembership.create({
-      data: {
-        group_id: group[0].id,
-        user_id: id
-      }
-    });
-  }
+        await prisma.Group.create({
+            data: {
+                name,
+                groupAdmin: id,
+            },
+        });
 
-  async save() {
-    await this.isDuplicate();
-    await this.createGroup();
-  }
+        const group = await prisma.$queryRaw`SELECT "id" FROM "Group" WHERE "name" = ${name} AND "groupAdmin" = ${id}`;
+
+        await prisma.GroupMembership.create({
+            data: {
+                group_id: group[0].id,
+                user_id: id,
+            },
+        });
+    }
+
+    static async isGroupAdmin(groupId, userId) {
+        const record = await prisma.Group.findUnique({
+            where: {
+                id: Number(groupId),
+            },
+        });
+        if (record.groupAdmin !== userId) {
+            throw new HttpError(403, 'Only the Group administrator can add users');
+        }
+    }
+
+    static async sanitizeData(arr, groupId) {
+        const results = [];
+
+        for (const obj of arr) {
+            const result = prisma.$queryRaw`SELECT user_id FROM "GroupMembership" WHERE "group_id" = ${Number(groupId)} AND "user_id" = ${obj.user_id}`;
+            results.push(result);
+        }
+        const awaitedResults = await Promise.all(results);
+        for (let i = 0; i < awaitedResults.length; i += 1) {
+            if (awaitedResults[i].length) {
+                for (let j = 0; j < awaitedResults[i].length; j += 1) {
+                    for (const [index, value] of arr.entries()) {
+                        if (value.user_id === awaitedResults[i][j].user_id) {
+                            // remove entries that already exist in the group
+                            arr.splice(index, 1);
+                        }
+                    }
+                }
+            }
+        }
+
+        return arr;
+    }
+
+    static async addUsers(arr, groupId, userId) {
+        await Group.isGroupAdmin(groupId, userId);
+        const newUsers = await Group.sanitizeData(arr, groupId);
+
+        if (newUsers.length === 0) {
+            throw new HttpError(409, 'All the users submitted already exist in the group');
+        }
+        newUsers.forEach((object) => {
+            object.group_id = Number(groupId);
+        });
+        await prisma.GroupMembership.createMany({
+            data: newUsers
+        });
+    }
+
+    async save() {
+        await this.isDuplicate();
+        await this.createGroup();
+    }
 }
 module.exports = Group;

--- a/server/models/groups.js
+++ b/server/models/groups.js
@@ -53,7 +53,7 @@ class Group {
             throw new HttpError(403, 'Only the Group administrator can add users');
         }
     }
-
+    
     static async sanitizeData(arr, groupId) {
         const results = [];
 
@@ -62,20 +62,13 @@ class Group {
             results.push(result);
         }
         const awaitedResults = await Promise.all(results);
-        for (let i = 0; i < awaitedResults.length; i += 1) {
-            if (awaitedResults[i].length) {
-                for (let j = 0; j < awaitedResults[i].length; j += 1) {
-                    for (const [index, value] of arr.entries()) {
-                        if (value.user_id === awaitedResults[i][j].user_id) {
-                            // remove entries that already exist in the group
-                            arr.splice(index, 1);
-                        }
-                    }
-                }
-            }
-        }
-
-        return arr;
+        const filteredAwaitedResults = awaitedResults.filter(obj => obj.length > 0);
+        
+        const result = arr.filter(element => {
+          return filteredAwaitedResults.every(obj=> obj[0].user_id !== element.user_id);
+        });
+        return result;
+      
     }
 
     static async addUsers(arr, groupId, userId) {

--- a/server/routes/group/add-users-to-group.js
+++ b/server/routes/group/add-users-to-group.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const { HttpError } = require('../../utils/errors');
+const { Group } = require('../../models');
+const { authenticateToken } = require('../../utils/token-helpers');
+
+const router = express.Router();
+router.post('/:id/user', authenticateToken, async (req, res) => {
+    const { data } = req.body;
+    const { id } = req.user;
+    if (!Array.isArray(data)) {
+        return res.status(400).json({ message: 'Invalid Payload' });
+    }
+
+    try {
+        await Group.addUsers(data, req.params.id, id);
+        return res.status(201).json({ message: 'group user(s) successfully added' });
+    } catch (error) {
+        if (error instanceof HttpError) {
+            return res.status(error.statusCode).json({ message: error.message });
+        }
+        return res.status(500).json({ message: error.message });
+    }
+});
+module.exports = router;

--- a/server/routes/group/add-users-to-group.js
+++ b/server/routes/group/add-users-to-group.js
@@ -7,12 +7,13 @@ const router = express.Router();
 router.post('/:id/user', authenticateToken, async (req, res) => {
     const { data } = req.body;
     const { id } = req.user;
+    const groupId  = req.params.id;
     if (!Array.isArray(data)) {
         return res.status(400).json({ message: 'Invalid Payload' });
     }
 
     try {
-        await Group.addUsers(data, req.params.id, id);
+        await Group.addUsers(data, groupId, id);
         return res.status(201).json({ message: 'group user(s) successfully added' });
     } catch (error) {
         if (error instanceof HttpError) {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -3,11 +3,13 @@ const signinRouter = require('./user/signin');
 const refreshTokenRouter = require('./user/refresh-token');
 const logoutRouter = require('./user/logout');
 const createBroadcastGroupRouter = require('./group/create-broadcast-group');
+const addUsersToGroupRouter = require('./group/add-users-to-group');
 
 module.exports = {
-  signupRouter,
-  signinRouter,
-  refreshTokenRouter,
-  logoutRouter,
-  createBroadcastGroupRouter
+    signupRouter,
+    signinRouter,
+    refreshTokenRouter,
+    logoutRouter,
+    createBroadcastGroupRouter,
+    addUsersToGroupRouter
 };

--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,13 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const {
-  signupRouter, signinRouter, refreshTokenRouter, logoutRouter, createBroadcastGroupRouter
+    signupRouter,
+    signinRouter,
+    refreshTokenRouter,
+    logoutRouter,
+    createBroadcastGroupRouter,
+    addUsersToGroupRouter,
+
 } = require('./routes');
 
 const app = express();
@@ -12,4 +18,5 @@ app.use('/api/user', signinRouter);
 app.use('/api', logoutRouter);
 app.use('/api', refreshTokenRouter);
 app.use('/api', createBroadcastGroupRouter);
+app.use('/api/group', addUsersToGroupRouter);
 module.exports = app;

--- a/server/utils/token-helpers/verify-access-token.js
+++ b/server/utils/token-helpers/verify-access-token.js
@@ -4,7 +4,6 @@ const jwt = require('jsonwebtoken');
 function verifyAccessToken(token) {
   try {
     const record = jwt.verify(token, process.env.ACCESS_TOKEN_SECRET);
-    console.log(record)
     return record;
   } catch (error) { return false; }
 }


### PR DESCRIPTION
**What does this PR do?**
This PR enables users to add other users to broadcast groups in to the PostIt Application.

**Description of the task to be completed**
For registered group administrators to be able to add other users in the broadcast group

**Why do we need this feature?**
To enable users to add other users in the broadcast groups

**How can this feature be manually tested?**
Using **Postman** POST:` http:localhost:3000/api/group/:id/user`

Post a JSON object in the form
```
{"data":[{"user_id":1},{"user_id":2}]}
```
to add users to a broadcast group

**Testing** 


```
npm run test

```