### PR TITLE
View group messages

### DIFF
--- a/server/__tests__/message.tests.js
+++ b/server/__tests__/message.tests.js
@@ -1,20 +1,32 @@
 /* eslint-disable no-undef */
 const { Message } = require('../models');
 const { HttpError } = require('../utils/errors');
+const { prismaMock } = require('../db/singleton');
 
 const record = {
+    user_id: 3,
     msg: 'This is a test',
+    createdAt: '2023-01-10 12:07:47.439'
 };
 const groupId = 1;
 const userId = 1;
 const { msg } = record;
-const message = new Message(userId,msg,groupId);
+const message = new Message(userId,groupId,msg);
 describe('When a user posts a message to a group', () => {
     it('it should throw an error if the user is not authorized to post to the group', async () => {
         jest
             .spyOn(message, 'isGroupUser')
             .mockImplementationOnce(() => Promise.reject(new HttpError(403, 'You do not belong to this group, cannot post here!')));
         await expect(message.add()).rejects.toThrow('You do not belong to this group, cannot post here!');
+    });
+});
+describe('When a user views messages in a group', () => {
+    it('it should return a record of messages posted in the group', async () => {
+        jest
+            .spyOn(message, 'isGroupUser')
+            .mockImplementationOnce(() => Promise.resolve());
+        prismaMock.$queryRaw.mockResolvedValue(record);
+        await expect(message.view()).resolves.toEqual(record);
     });
 });
 

--- a/server/__tests__/post-group-message-tests.js
+++ b/server/__tests__/post-group-message-tests.js
@@ -27,10 +27,10 @@ afterAll(() => {
 });
 
 const record = {
-  msg: 'This is a test'
+  userMessage: 'This is a test'
 };
 
-const { msg } = record;
+const { userMessage } = record;
 
 const token = 'token';
 
@@ -47,21 +47,21 @@ describe('When a user posts a message to a group', () => {
     Message.mockImplementationOnce(() => ({
       add: jest.fn(() => Promise.resolve()),
     }));
-    const response = await request(baseURL).post('/api/group/:id/message').set('Authorization', `Bearer ${token}`).send({ msg });
+    const response = await request(baseURL).post('/api/group/:id/message').set('Authorization', `Bearer ${token}`).send({ userMessage });
     expect(response.statusCode).toBe(201);
   });
   it('should return correct status code if the user is not authorized to post in the group', async () => {
     Message.mockImplementationOnce(() => ({
       add: jest.fn(() => Promise.reject(new HttpError(403, 'You do not belong to this group, cannot post here!'))),
     }));
-    const response = await request(baseURL).post('/api/group/:id/message').set('Authorization', `Bearer ${token}`).send({ msg });
+    const response = await request(baseURL).post('/api/group/:id/message').set('Authorization', `Bearer ${token}`).send({ userMessage });
     expect(response.statusCode).toBe(403);
   });
   it('should return correct status code on an unexpected error', async () => {
     Message.mockImplementationOnce(() => ({
       add: jest.fn(() => Promise.reject(new Error(500, 'Interval server'))),
     }));
-    const response = await request(baseURL).post('/api/group/:id/message').set('Authorization', `Bearer ${token}`).send({ msg });
+    const response = await request(baseURL).post('/api/group/:id/message').set('Authorization', `Bearer ${token}`).send({ userMessage });
     expect(response.statusCode).toBe(500);
   });
 });

--- a/server/__tests__/view-group-messages-tests.js
+++ b/server/__tests__/view-group-messages-tests.js
@@ -26,6 +26,9 @@ afterAll(() => {
   server.close();
 });
 
+const record = {
+    message: "This is a test"
+}
 const token = 'token';
 
 const baseURL = 'http://localhost:3001';
@@ -33,10 +36,11 @@ const baseURL = 'http://localhost:3001';
 describe('When a user views messages in a group', () => {
   it('should return correct status code if the user is viewing messages', async () => {
     Message.mockImplementationOnce(() => ({
-      view: jest.fn(() => Promise.resolve()),
+      view: jest.fn(() => Promise.resolve(record)),
     }));
     const response = await request(baseURL).get('/api/group/:id/messages').set('Authorization', `Bearer ${token}`);
     expect(response.statusCode).toBe(200);
+    expect(response.body.message).toStrictEqual(record);
   });
   it('should return correct status code if the user is not authorized to view messages in the group', async () => {
     Message.mockImplementationOnce(() => ({

--- a/server/__tests__/view-group-messages-tests.js
+++ b/server/__tests__/view-group-messages-tests.js
@@ -1,0 +1,55 @@
+/* eslint-disable no-undef */
+const request = require('supertest');
+const { Message } = require('../models');
+
+const app = require('../server');
+const { HttpError } = require('../utils/errors');
+
+let server;
+jest.mock('../models', () => ({
+  Message: jest.fn()
+}));
+jest.mock('../utils/token-helpers', () => ({
+  authenticateToken: jest.fn().mockImplementation((req, res, next) => {
+    const user = {
+      id: '1'
+    };
+    req.user = user;
+    next();
+  }),
+}));
+beforeAll(() => {
+  server = app.listen(3001);
+});
+
+afterAll(() => {
+  server.close();
+});
+
+const token = 'token';
+
+const baseURL = 'http://localhost:3001';
+
+describe('When a user views messages in a group', () => {
+  it('should return correct status code if the user is viewing messages', async () => {
+    Message.mockImplementationOnce(() => ({
+      view: jest.fn(() => Promise.resolve()),
+    }));
+    const response = await request(baseURL).get('/api/group/:id/messages').set('Authorization', `Bearer ${token}`);
+    expect(response.statusCode).toBe(200);
+  });
+  it('should return correct status code if the user is not authorized to view messages in the group', async () => {
+    Message.mockImplementationOnce(() => ({
+      view: jest.fn(() => Promise.reject(new HttpError(403, 'You do not belong to this group'))),
+    }));
+    const response = await request(baseURL).get('/api/group/:id/messages').set('Authorization', `Bearer ${token}`);
+    expect(response.statusCode).toBe(403);
+  });
+  it('should return correct status code on an unexpected error', async () => {
+    Message.mockImplementationOnce(() => ({
+      view: jest.fn(() => Promise.reject(new Error(500, 'Interval server'))),
+    }));
+    const response = await request(baseURL).get('/api/group/:id/messages').set('Authorization', `Bearer ${token}`);
+    expect(response.statusCode).toBe(500);
+  });
+});

--- a/server/models/messages.js
+++ b/server/models/messages.js
@@ -12,7 +12,7 @@ class Message {
    const record = await prisma.$queryRaw`SELECT  user_id FROM "GroupMembership" WHERE "group_id"= ${groupId} AND "user_id" = ${userId}`;
    
    if(!record.length){
-      throw new HttpError(403,"You do not belong to this group, cannot post here!");
+      throw new HttpError(403,"You do not belong to this group");
    }
 }
 
@@ -27,6 +27,17 @@ class Message {
          message: message
       }
    });
+ }
+ async view(){
+   const {groupId} = this;
+
+   await this.isGroupUser();
+
+   const records = await prisma.$queryRaw`SELECT "user_id","message","createdAt" FROM "GroupMessages" WHERE "group_id" = ${groupId} ORDER BY "id" ASC`;
+   if(!records){
+      throw new HttpError(404,'Could not find group messages');
+   }
+   return records;
  }
 }
 

--- a/server/models/messages.js
+++ b/server/models/messages.js
@@ -1,7 +1,7 @@
 const {HttpError} = require('../utils/errors');
 const prisma = require('../db');
 class Message {
- constructor(userId,message,groupId){
+ constructor(userId,groupId,message=""){
     this.userId = userId;
     this.message = message;
     this.groupId = groupId;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -5,6 +5,7 @@ const logoutRouter = require('./user/logout');
 const createBroadcastGroupRouter = require('./group/create-broadcast-group');
 const addUsersToGroupRouter = require('./group/add-users-to-group');
 const postGroupMessageRouter = require('./message/post-group-message');
+const viewGroupMessageRouter = require('./message/view-group-message')
 
 module.exports = {
     signupRouter,
@@ -13,5 +14,6 @@ module.exports = {
     logoutRouter,
     createBroadcastGroupRouter,
     addUsersToGroupRouter,
-    postGroupMessageRouter
+    postGroupMessageRouter,
+    viewGroupMessageRouter
 };

--- a/server/routes/message/post-group-message.js
+++ b/server/routes/message/post-group-message.js
@@ -13,7 +13,7 @@ router.post('/:id/message', authenticateToken, async (req, res) => {
     }
 
     try {
-        const message = new Message(id,msg,groupId);
+        const message = new Message(id,groupId,msg);
         await message.add();
         return res.status(201).json({ message: 'Message sent' });
     } catch (error) {

--- a/server/routes/message/post-group-message.js
+++ b/server/routes/message/post-group-message.js
@@ -5,15 +5,15 @@ const { authenticateToken } = require('../../utils/token-helpers');
 
 const router = express.Router();
 router.post('/:id/message', authenticateToken, async (req, res) => {
-    const { msg } = req.body;
+    const { userMessage } = req.body;
     const { id } = req.user;
     const groupId  = Number(req.params.id);
-    if (!msg) {
+    if (!userMessage) {
         return res.status(400).json({ message: 'Invalid Payload' });
     }
 
     try {
-        const message = new Message(id,groupId,msg);
+        const message = new Message(id,groupId,userMessage);
         await message.add();
         return res.status(201).json({ message: 'Message sent' });
     } catch (error) {

--- a/server/routes/message/view-group-message.js
+++ b/server/routes/message/view-group-message.js
@@ -10,8 +10,8 @@ router.get('/:id/messages', authenticateToken, async (req, res) => {
 
     try {
         const message = new Message(id,groupId);
-        await message.view();
-        return res.status(200).json({ message: 'Viewing Messages' });
+        const messages = await message.view();
+        return res.status(200).json({ message: messages });
     } catch (error) {
         if (error instanceof HttpError) {
             return res.status(error.statusCode).json({ message: error.message });

--- a/server/routes/message/view-group-message.js
+++ b/server/routes/message/view-group-message.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const { HttpError } = require('../../utils/errors');
+const { Message } = require('../../models');
+const { authenticateToken } = require('../../utils/token-helpers');
+
+const router = express.Router();
+router.get('/:id/messages', authenticateToken, async (req, res) => {
+    const { id } = req.user;
+    const groupId  = Number(req.params.id);
+
+    try {
+        const message = new Message(id,groupId);
+        await message.view();
+        return res.status(200).json({ message: 'Viewing Messages' });
+    } catch (error) {
+        if (error instanceof HttpError) {
+            return res.status(error.statusCode).json({ message: error.message });
+        }
+        return res.status(500).json({ message: error.message });
+    }
+});
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -7,7 +7,8 @@ const {
     logoutRouter,
     createBroadcastGroupRouter,
     addUsersToGroupRouter,
-    postGroupMessageRouter
+    postGroupMessageRouter,
+    viewGroupMessageRouter
 
 } = require('./routes');
 
@@ -21,4 +22,5 @@ app.use('/api', refreshTokenRouter);
 app.use('/api', createBroadcastGroupRouter);
 app.use('/api/group', addUsersToGroupRouter);
 app.use('/api/group', postGroupMessageRouter);
+app.use('/api/group', viewGroupMessageRouter);
 module.exports = app;


### PR DESCRIPTION
**What does this PR do?**
This PR enables users to view messages in the broadcast groups they belong to in to the PostIt Application.

**Description of the task to be completed**
For registered group users to be able to add view messages to their broadcast group(s)

**Why do we need this feature?**
To enable users to view messages in broadcast groups they belong to

**How can this feature be manually tested?**
Using **Postman** GET:` http:localhost:3000/api/group/:id/messages`


**Testing** 


```
npm run test

```